### PR TITLE
Added handling of dirtying in materializing state

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -547,7 +547,17 @@ var states = {
         didChangeData: didChangeData,
 
         finishedMaterializing: function(manager) {
-          manager.transitionTo('loaded.saved');
+          var isDirty = get(manager, 'dirtyWhileMaterializing');
+          if (isDirty) {
+            manager.transitionTo('loaded.updated');
+            set(manager, 'dirtyWhileMaterializing', false);
+          } else {
+            manager.transitionTo('loaded.saved');
+          }
+        },
+
+        becomeDirty: function(manager) {
+          set(manager, 'dirtyWhileMaterializing', true);
         },
 
         // SUBSTATES


### PR DESCRIPTION
We mark the record as dirtyWhileMaterialzing, and then transition to
loaded.updated once we are on finishedMaterializing.
