### PR TITLE
Encode URI components on IDs in build URL because they can be strings

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -396,7 +396,7 @@ DS.RESTAdapter = DS.Adapter.extend({
         prefix = this.urlPrefix();
 
     if (type) { url.push(this.pathForType(type)); }
-    if (id) { url.push(id); }
+    if (id) { url.push(encodeURIComponent(id)); }
 
     if (prefix) { url.unshift(prefix); }
 


### PR DESCRIPTION
@karthik-rangarajan @cyril-sf @sreenath-addepar 

Backport of https://github.com/emberjs/data/commit/3681fcf463204bfc0acf307cbe8ff0aa4e95efb9 but without the tests. Can be undone when we upgrade to beta 11 or better.