### PR TITLE
Fix clearRelationships on hasMany relationships when record is deleted

### DIFF
--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -118,7 +118,7 @@ function updatePayloadWithEmbedded(store, serializer, type, partial, payload) {
     if (config && (config.embedded === 'always' || config.embedded === 'load')) {
       // underscore forces the embedded records to be side loaded.
       // it is needed when main type === relationship.type
-      embeddedTypeKey = '_' + Ember.String.pluralize(relationship.type.typeKey);
+      embeddedTypeKey = '_' + serializer.typeForRoot(relationship.type.typeKey);
       expandedKey = this.keyForRelationship(key, relationship.kind);
       attribute  = this.keyForAttribute(key);
       ids = [];

--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -75,10 +75,32 @@ DS.EmbeddedRecordsMixin = Ember.Mixin.create({
     @method extractSingle
   */
   extractSingle: function(store, primaryType, payload, recordId, requestType) {
-    var root = this.keyForAttribute(primaryType.typeKey),
-        partial = payload[root];
+    var objectKeys = Object.keys(payload);
 
-    updatePayloadWithEmbedded(store, this, primaryType, partial, payload);
+    for (var i = 0; i < objectKeys.length; i += 1) {
+      var objectKey = objectKeys[i];
+
+      // We only want objects from the original payload, any objects added
+      // later are assumed to be prefixed with an underscore _
+      if (objectKey.charAt(0) === "_") {
+        continue;
+      }
+
+      var typeKey = this.typeForRoot(objectKey);
+      var type = store.modelFor(typeKey);
+
+      var partial = payload[objectKey];
+      var serializer = store.serializerFor(type);
+
+      if (type === primaryType){
+        updatePayloadWithEmbedded(store, serializer, type, partial, payload);
+      } else {
+
+        forEach(partial, function(singleObjectPartial) {
+          updatePayloadWithEmbedded(store, serializer, type, singleObjectPartial, payload);
+        }, this);
+      }
+    }
 
     return this._super(store, primaryType, payload, recordId, requestType);
   },
@@ -102,6 +124,12 @@ DS.EmbeddedRecordsMixin = Ember.Mixin.create({
 });
 
 function updatePayloadWithEmbedded(store, serializer, type, partial, payload) {
+  if (type.detectDynamicType) {
+    type = type.detectDynamicType(partial.type);
+  }
+
+  serializer = store.serializerFor(type);
+
   var attrs = get(serializer, 'attrs');
 
   if (!attrs) {

--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -75,32 +75,10 @@ DS.EmbeddedRecordsMixin = Ember.Mixin.create({
     @method extractSingle
   */
   extractSingle: function(store, primaryType, payload, recordId, requestType) {
-    var objectKeys = Object.keys(payload);
+    var root = this.keyForAttribute(primaryType.typeKey),
+        partial = payload[root];
 
-    for (var i = 0; i < objectKeys.length; i += 1) {
-      var objectKey = objectKeys[i];
-
-      // We only want objects from the original payload, any objects added
-      // later are assumed to be prefixed with an underscore _
-      if (objectKey.charAt(0) === "_") {
-        continue;
-      }
-
-      var typeKey = this.typeForRoot(objectKey);
-      var type = store.modelFor(typeKey);
-
-      var partial = payload[objectKey];
-      var serializer = store.serializerFor(type);
-
-      if (type === primaryType){
-        updatePayloadWithEmbedded(store, serializer, type, partial, payload);
-      } else {
-
-        forEach(partial, function(singleObjectPartial) {
-          updatePayloadWithEmbedded(store, serializer, type, singleObjectPartial, payload);
-        }, this);
-      }
-    }
+    updatePayloadWithEmbedded(store, this, primaryType, partial, payload);
 
     return this._super(store, primaryType, payload, recordId, requestType);
   },
@@ -124,12 +102,6 @@ DS.EmbeddedRecordsMixin = Ember.Mixin.create({
 });
 
 function updatePayloadWithEmbedded(store, serializer, type, partial, payload) {
-  if (type.detectDynamicType) {
-    type = type.detectDynamicType(partial.type);
-  }
-
-  serializer = store.serializerFor(type);
-
   var attrs = get(serializer, 'attrs');
 
   if (!attrs) {

--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -119,8 +119,8 @@ function updatePayloadWithEmbedded(store, serializer, type, partial, payload) {
       // underscore forces the embedded records to be side loaded.
       // it is needed when main type === relationship.type
       embeddedTypeKey = '_' + serializer.typeForRoot(relationship.type.typeKey);
-      expandedKey = this.keyForRelationship(key, relationship.kind);
-      attribute  = this.keyForAttribute(key);
+      expandedKey = serializer.keyForRelationship(key, relationship.kind);
+      attribute  = serializer.keyForAttribute(key);
       ids = [];
 
       if (!partial[attribute]) {

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -118,7 +118,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     The `find` method makes an Ajax request to a URL computed by `buildURL`, and returns a
     promise for the resulting payload.
 
-    This method performs an HTTP `GET` request with the id provided as part of the querystring. 
+    This method performs an HTTP `GET` request with the id provided as part of the querystring.
 
     @method find
     @see RESTAdapter/buildURL
@@ -302,7 +302,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     Called by the store when a newly created record is
     saved via the `save` method on a model record instance.
 
-    The `createRecord` method serializes the record and makes an Ajax (HTTP POST) request 
+    The `createRecord` method serializes the record and makes an Ajax (HTTP POST) request
     to a URL computed by `buildURL`.
 
     See `serialize` for information on how to customize the serialized form
@@ -327,10 +327,10 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   /**
-    Called by the store when an existing record is saved 
+    Called by the store when an existing record is saved
     via the `save` method on a model record instance.
-    
-    The `updateRecord` method serializes the record and makes an Ajax (HTTP PUT) request 
+
+    The `updateRecord` method serializes the record and makes an Ajax (HTTP PUT) request
     to a URL computed by `buildURL`.
 
     See `serialize` for information on how to customize the serialized form
@@ -510,6 +510,12 @@ DS.RESTAdapter = DS.Adapter.extend({
       hash = adapter.ajaxOptions(url, type, hash);
 
       hash.success = function(json) {
+        // Prevent errors when the result of a XHR request comes back after
+        // the store has been destroyed.
+        // This happens when in test `deactivate` of a route `reload`s a record
+        if(adapter.isDestroying) {
+          return;
+        }
         Ember.run(null, resolve, json);
       };
 

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -118,7 +118,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     The `find` method makes an Ajax request to a URL computed by `buildURL`, and returns a
     promise for the resulting payload.
 
-    This method performs an HTTP `GET` request with the id provided as part of the querystring.
+    This method performs an HTTP `GET` request with the id provided as part of the querystring. 
 
     @method find
     @see RESTAdapter/buildURL
@@ -302,7 +302,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     Called by the store when a newly created record is
     saved via the `save` method on a model record instance.
 
-    The `createRecord` method serializes the record and makes an Ajax (HTTP POST) request
+    The `createRecord` method serializes the record and makes an Ajax (HTTP POST) request 
     to a URL computed by `buildURL`.
 
     See `serialize` for information on how to customize the serialized form
@@ -327,10 +327,10 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   /**
-    Called by the store when an existing record is saved
+    Called by the store when an existing record is saved 
     via the `save` method on a model record instance.
-
-    The `updateRecord` method serializes the record and makes an Ajax (HTTP PUT) request
+    
+    The `updateRecord` method serializes the record and makes an Ajax (HTTP PUT) request 
     to a URL computed by `buildURL`.
 
     See `serialize` for information on how to customize the serialized form
@@ -510,12 +510,6 @@ DS.RESTAdapter = DS.Adapter.extend({
       hash = adapter.ajaxOptions(url, type, hash);
 
       hash.success = function(json) {
-        // Prevent errors when the result of a XHR request comes back after
-        // the store has been destroyed.
-        // This happens when in test `deactivate` of a route `reload`s a record
-        if(adapter.isDestroying) {
-          return;
-        }
         Ember.run(null, resolve, json);
       };
 

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -396,7 +396,7 @@ DS.RESTAdapter = DS.Adapter.extend({
         prefix = this.urlPrefix();
 
     if (type) { url.push(this.pathForType(type)); }
-    if (id) { url.push(id); }
+    if (id) { url.push(encodeURIComponent(id)); }
 
     if (prefix) { url.unshift(prefix); }
 

--- a/packages/ember-data/lib/system/changes/relationship_change.js
+++ b/packages/ember-data/lib/system/changes/relationship_change.js
@@ -73,7 +73,6 @@ DS.RelationshipChange._createChange = function(options){
   }
 };
 
-
 DS.RelationshipChange.determineRelationshipType = function(recordType, knownSide){
   var knownKey = knownSide.key, key, otherKind;
   var knownKind = knownSide.kind;
@@ -96,7 +95,6 @@ DS.RelationshipChange.determineRelationshipType = function(recordType, knownSide
       return knownKind === "belongsTo" ? "oneToMany" : "manyToMany";
     }
   }
-
 };
 
 DS.RelationshipChange.createChange = function(firstRecord, secondRecord, store, options){
@@ -265,7 +263,6 @@ DS.OneToManyChange.createChange = function(childRecord, parentRecord, store, opt
   return change;
 };
 
-
 DS.OneToManyChange.maintainInvariant = function(options, store, childRecord, key){
   if (options.changeType === "add" && childRecord) {
     var oldParent = get(childRecord, key);
@@ -355,9 +352,11 @@ DS.RelationshipChange.prototype = {
 DS.RelationshipChangeAdd.prototype = Ember.create(DS.RelationshipChange.create({}));
 DS.RelationshipChangeRemove.prototype = Ember.create(DS.RelationshipChange.create({}));
 
-// the object is a value, and not a promise
-function isValue(object) {
-  return typeof object === 'object' && (!object.then || typeof object.then !== 'function');
+function isSyncRelationship(record, relationshipName) {
+  var meta = Ember.meta(record);
+  var desc = meta.descs[relationshipName];
+
+  return desc && !desc._meta.options.async;
 }
 
 DS.RelationshipChangeAdd.prototype.changeType = "add";
@@ -375,12 +374,10 @@ DS.RelationshipChangeAdd.prototype.sync = function() {
       secondRecord.suspendRelationshipObservers(function(){
         set(secondRecord, secondRecordName, firstRecord);
       });
-
-     }
-     else if(this.secondRecordKind === "hasMany"){
-      secondRecord.suspendRelationshipObservers(function(){
+    } else if (this.secondRecordKind === 'hasMany' && isSyncRelationship(secondRecord, secondRecordName)) {
+      secondRecord.suspendRelationshipObservers(function() {
         var relationship = get(secondRecord, secondRecordName);
-        if (isValue(relationship)) { relationship.addObject(firstRecord); }
+        relationship.addObject(firstRecord);
       });
     }
   }
@@ -390,15 +387,13 @@ DS.RelationshipChangeAdd.prototype.sync = function() {
       firstRecord.suspendRelationshipObservers(function(){
         set(firstRecord, firstRecordName, secondRecord);
       });
-    }
-    else if(this.firstRecordKind === "hasMany"){
-      firstRecord.suspendRelationshipObservers(function(){
+    } else if (this.firstRecordKind === 'hasMany' && isSyncRelationship(secondRecord, secondRecordName)) {
+      firstRecord.suspendRelationshipObservers(function() {
         var relationship = get(firstRecord, firstRecordName);
-        if (isValue(relationship)) { relationship.addObject(secondRecord); }
+         relationship.addObject(secondRecord);
       });
     }
   }
-
   this.coalesce();
 };
 
@@ -417,11 +412,10 @@ DS.RelationshipChangeRemove.prototype.sync = function() {
       secondRecord.suspendRelationshipObservers(function(){
         set(secondRecord, secondRecordName, null);
       });
-    }
-    else if(this.secondRecordKind === "hasMany"){
-      secondRecord.suspendRelationshipObservers(function(){
+    } else if (this.secondRecordKind === 'hasMany' && isSyncRelationship(secondRecord, secondRecordName)) {
+      secondRecord.suspendRelationshipObservers(function() {
         var relationship = get(secondRecord, secondRecordName);
-        if (isValue(relationship)) { relationship.removeObject(firstRecord); }
+        relationship.removeObject(firstRecord);
       });
     }
   }
@@ -431,11 +425,10 @@ DS.RelationshipChangeRemove.prototype.sync = function() {
       firstRecord.suspendRelationshipObservers(function(){
         set(firstRecord, firstRecordName, null);
       });
-     }
-     else if(this.firstRecordKind === "hasMany"){
-       firstRecord.suspendRelationshipObservers(function(){
-         var relationship = get(firstRecord, firstRecordName);
-         if (isValue(relationship)) { relationship.removeObject(secondRecord); }
+    } else if (this.firstRecordKind === 'hasMany' && isSyncRelationship(firstRecord, firstRecordName)) {
+      firstRecord.suspendRelationshipObservers(function() {
+        var relationship = get(firstRecord, firstRecordName);
+        relationship.removeObject(secondRecord);
       });
     }
   }

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -143,7 +143,7 @@ DS.Model.reopenClass({
     @static
   */
   eachAttribute: function(callback, binding) {
-    get(this, 'attributes').forEach(function(name, meta) {
+    get(this, 'attributes').forEach(function(meta, name) {
       callback.call(binding, name, meta);
     }, binding);
   },
@@ -191,7 +191,7 @@ DS.Model.reopenClass({
     @static
   */
   eachTransformedAttribute: function(callback, binding) {
-    get(this, 'transformedAttributes').forEach(function(name, type) {
+    get(this, 'transformedAttributes').forEach(function(type, name) {
       callback.call(binding, name, type);
     });
   }

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -260,7 +260,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
       if (relationship.kind === 'belongsTo') {
         set(this, name, null);
       } else if (relationship.kind === 'hasMany') {
-        var hasMany = this._relationships[relationship.name];
+        var hasMany = this._relationships[name];
         if (hasMany) { hasMany.clear(); }
       }
     }, this);

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -336,7 +336,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   reloadHasManys: function() {
     var relationships = get(this.constructor, 'relationshipsByName');
     this.updateRecordArraysLater();
-    relationships.forEach(function(name, relationship) {
+    relationships.forEach(function(relationship, name) {
       if (this._data.links && this._data.links[name]) { return; }
       if (relationship.kind === 'hasMany') {
         this.hasManyDidChange(relationship.key);

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -5,7 +5,7 @@ require("ember-data/system/model/states");
 */
 
 var get = Ember.get, set = Ember.set,
-    merge = Ember.merge, once = Ember.run.once;
+    merge = Ember.merge;
 
 var retrieveFromCurrentState = Ember.computed('currentState', function(key, value) {
   return get(get(this, 'currentState'), key);
@@ -538,8 +538,8 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   triggerLater: function() {
-    this._deferredTriggers.push(arguments);
-    once(this, '_triggerDeferredTriggers');
+    if (this._deferredTriggers.push(arguments) !== 1) { return; }
+    Ember.run.schedule('actions', this, '_triggerDeferredTriggers');
   },
 
   _triggerDeferredTriggers: function() {
@@ -547,7 +547,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
       this.trigger.apply(this, this._deferredTriggers[i]);
     }
 
-    this._deferredTriggers = [];
+    this._deferredTriggers.length = 0;
   }
 });
 

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -267,6 +267,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   updateRecordArrays: function() {
+    this._updatingRecordArraysLater = false;
     get(this, 'store').dataWasUpdated(this.constructor, this);
   },
 
@@ -356,7 +357,11 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   updateRecordArraysLater: function() {
-    Ember.run.once(this, this.updateRecordArrays);
+    // quick hack (something like this could be pushed into run.once
+    if (this._updatingRecordArraysLater) { return; }
+    this._updatingRecordArraysLater = true;
+
+    Ember.run.schedule('actions', this, this.updateRecordArrays);
   },
 
   setupData: function(data, partial) {

--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -112,7 +112,7 @@ DS.RecordArrayManager = Ember.Object.extend({
       recordArrays.add(array);
       array.addRecord(record);
     } else if (!shouldBeInArray) {
-      recordArrays.remove(array);
+      recordArrays.delete(array);
       array.removeRecord(record);
     }
   },

--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -3,7 +3,6 @@
 */
 
 var get = Ember.get, set = Ember.set;
-var once = Ember.run.once;
 var forEach = Ember.EnumerableUtils.forEach;
 
 /**
@@ -22,8 +21,9 @@ DS.RecordArrayManager = Ember.Object.extend({
   },
 
   recordDidChange: function(record) {
-    this.changedRecords.push(record);
-    once(this, this.updateRecordArrays);
+    if (this.changedRecords.push(record) !== 1) { return; }
+
+    Ember.run.schedule('actions', this, this.updateRecordArrays);
   },
 
   recordArraysForRecord: function(record) {
@@ -52,7 +52,7 @@ DS.RecordArrayManager = Ember.Object.extend({
       }
     }, this);
 
-    this.changedRecords = [];
+    this.changedRecords.length = 0;
   },
 
   _recordWasDeleted: function (record) {

--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -1,6 +1,13 @@
 var get = Ember.get, set = Ember.set,
     isNone = Ember.isNone;
 
+function isSyncRelationship(record, relationshipName) {
+  var meta = Ember.meta(record);
+  var desc = meta.descs[relationshipName];
+
+  return desc && !desc._meta.options.async;
+}
+
 /**
   @module ember-data
 */
@@ -89,7 +96,7 @@ DS.Model.reopen({
     @param key
   */
   belongsToWillChange: Ember.beforeObserver(function(record, key) {
-    if (get(record, 'isLoaded')) {
+    if (get(record, 'isLoaded') && isSyncRelationship(record, key)) {
       var oldParent = get(record, key);
 
       if (oldParent) {

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -107,7 +107,7 @@ DS.Model.reopenClass({
     var options = this.metaForProperty(name).options;
 
     if (options.inverse === null) { return null; }
-    
+
     var inverseName, inverseKind;
 
     if (options.inverse) {
@@ -249,7 +249,7 @@ DS.Model.reopenClass({
         App.Blog = DS.Model.extend({
           users: DS.hasMany('user'),
           owner: DS.belongsTo('user'),
-  
+
           posts: DS.hasMany('post')
         });
 
@@ -399,7 +399,7 @@ DS.Model.reopenClass({
     @param {any} binding the value to which the callback's `this` should be bound
   */
   eachRelationship: function(callback, binding) {
-    get(this, 'relationshipsByName').forEach(function(name, relationship) {
+    get(this, 'relationshipsByName').forEach(function(relationship, name) {
       callback.call(binding, name, relationship);
     });
   },

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -458,7 +458,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
       recordsByTypeMap.get(record.constructor).push(record);
     });
 
-    forEach(recordsByTypeMap, function(type, records) {
+    forEach(recordsByTypeMap, function(records, type) {
       var ids = records.mapProperty('id'),
           adapter = this.adapterFor(type);
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1345,6 +1345,10 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 });
 
 function normalizeRelationships(store, type, data, record) {
+  if (type.detectDynamicType) {
+    type = type.detectDynamicType(data.type);
+  }
+
   type.eachRelationship(function(key, relationship) {
     // A link (usually a URL) was already provided in
     // normalized form

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1543,7 +1543,7 @@ function _commit(adapter, store, operation, record) {
       promise = adapter[operation](store, type, record),
       serializer = serializerForAdapter(adapter, type);
 
-  Ember.assert("Your adapter's '" + operation + "' method must return a promise, but it returned " + promise, isThenable(promise));
+  Ember.assert("Your adapter's '" + operation + "' method must return a value, but it returned `undefined", promise !==undefined);
 
   return promise.then(function(payload) {
     if (payload) { payload = serializer.extract(store, type, payload, get(record, 'id'), operation); }

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -233,3 +233,90 @@ test("TODO (embedded): The store can serialize an embedded polymorphic belongsTo
   //equal(serialized.favourite_message.id, 1);
   //equal(serialized.favourite_message.embeddedType, 'comment');
 });
+
+test("relationshipsByName does not cache a factory", function() {
+
+  // The model is loaded up via a container. It has relationshipsByName
+  // called on it.
+  var modelViaFirstFactory = store.modelFor('user');
+  get(modelViaFirstFactory, 'relationshipsByName');
+
+  // An app is reset, or the container otherwise destroyed.
+  env.container.destroy();
+
+  // A new model for a relationship is created. Note that this may happen
+  // due to an extend call internal to MODEL_FACTORY_INJECTIONS.
+  NewMessage = Message.extend();
+  NewMessage.toString = stringify('Message');
+
+  // A new store is created.
+  env = setupStore({
+    user: User,
+    message: NewMessage
+  });
+  store = env.store;
+
+  // relationshipsByName is called again.
+  var modelViaSecondFactory = store.modelFor('user'),
+      relationshipsByName   = get(modelViaSecondFactory, 'relationshipsByName'),
+      messageType           = relationshipsByName.get('messages').type;
+
+  // A model is looked up in the store based on a string, via user input
+  var messageModelFromStore        = store.modelFor('message');
+  // And the model is lookup up internally via the relationship type
+  var messageModelFromRelationType = store.modelFor(messageType);
+
+  equal( messageModelFromRelationType, messageModelFromStore,
+         "model factory based on relationship type matches the model based on store.modelFor" );
+});
+
+test("asdf", function() {
+  expect(2);
+
+  /*  Scenario:
+   *  ---------
+   *
+   *    post HM async comments
+   *    comments bt sync post
+   *
+   *    scenario:
+   *     - post hm C [1,2,3]
+   *     - post has a partially realized comments array comment#1 has been realized
+   *     - comment has not yet realized its post relationship
+   *     - comment is destroyed
+   */
+
+  env.store.modelFor('post').reopen({
+    comments: DS.hasMany('comment', {
+      async: true,
+      inverse: 'post'
+    })
+  });
+
+  env.store.modelFor('comment').reopen({
+    post: DS.belongsTo('post', {
+    })
+  });
+
+  var post = env.store.push('post', {
+    id: 1,
+    comments: [1, 2, 3]
+  });
+
+  var comment = env.store.push('comment', {
+    id:   1,
+    post: 1
+  });
+
+  env.adapter.deleteRecord = function(store, type, record) {
+    ok(record instanceof type);
+    equal(record.id, 1, 'should first comment')
+    return record;
+  };
+
+  env.adapter.findMany = function(store, type, ids, records) {
+    ok(false, 'should not need to findMay more comments, but attempted to anyways');
+  };
+
+  comment.destroyRecord();
+});

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -310,7 +310,7 @@ test("asdf", function() {
 
   env.adapter.deleteRecord = function(store, type, record) {
     ok(record instanceof type);
-    equal(record.id, 1, 'should first comment')
+    equal(record.id, 1, 'should first comment');
     return record;
   };
 
@@ -319,4 +319,39 @@ test("asdf", function() {
   };
 
   comment.destroyRecord();
+});
+
+test("Destroying a record with an unloaded aync belongsTo association does not fetch the record", function() {
+  expect(2);
+  var post;
+
+  env.store.modelFor('message').reopen({
+    user: DS.hasMany('user', {
+      async: true
+    })
+  });
+
+  env.store.modelFor('post').reopen({
+    user: DS.belongsTo('user', {
+      async: true,
+      inverse: 'messages'
+    })
+  });
+
+  post = env.store.push('post', {
+    id: 1,
+    user: 2
+  });
+
+  env.adapter.find = function() {
+    throw new Error("Adapter's find method should not be called");
+  };
+
+  env.adapter.deleteRecord = function(store, type, record) {
+    ok(record instanceof type);
+    equal(record.id, 1, 'should first post');
+    return record;
+  };
+
+  post.destroyRecord();
 });


### PR DESCRIPTION
Backport from now until ember-data beta.7 (partial backport of https://github.com/emberjs/data/commit/f6666e5a858fa4d1860471beaaeb42b5dac56af8). Required for hasMany relationships to properly clear out when a model is deleted.

One of two bugs @sicasli and I found today. The other (that inverse relationships do not properly clear out) is resolved in ember-data beta.12. Enough stuff happens between then and where we are now and it's not pressing enough that I'm voting we don't try to backport it and just get the upgrade train rolling.

When a record with hasMany relationships is deleted, we need to clear out all of
its relations. This requires clearing the array hasMany relations are stored in.
The code to do this references `relationship.name` which is a nonexistent
property, so nothing ever gets cleared. The intent is to reference `name`
directly.

@cyril-sf @sicasli
