### PR TITLE
Add static security scanning with CodeQL (SAST)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: "Static security scanning"
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, master]
+    paths:
+      - '**.js'
+  schedule:
+    # Timezone: UTC
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 0 * * 0'
+jobs:
+  run:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows:
+      security-events: write
+      # only required for workflows in private repositories:
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,6 @@ jobs:
     permissions:
       # required for all workflows:
       security-events: write
-      # only required for workflows in private repositories:
-      actions: read
-      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Enables weekly CodeQL scans in addition to scans on pull requests.